### PR TITLE
Add fixed-code keyfob remotes from Flipper firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ decode every signal in it in parallel.
 Working receiver, narrow coverage. The signal path runs end to end against real
 off-air RF, there is an egui front end, and FM broadcast decodes to stereo audio
 with RDS, and ADS-B decodes aircraft off the air. What is missing is protocols:
-fifteen ISM device decoders are implemented where the goal is hundreds, and
+twenty-five ISM device decoders are implemented where the goal is hundreds, and
 only Fine Offset and ADS-B have been checked against real recordings.
 
 Proof it works: `crates/decode/tests/fineoffset_capture.rs` decodes a real

--- a/crates/decode/src/protocol.rs
+++ b/crates/decode/src/protocol.rs
@@ -161,6 +161,7 @@ impl Protocols {
         p.add(Box::new(came24_bit()));
         p.add(Box::new(NiceFlo));
         p.add(Box::new(Linear));
+        p.add(Box::new(LinearDelta3));
         p
     }
 

--- a/crates/decode/src/protocol.rs
+++ b/crates/decode/src/protocol.rs
@@ -152,6 +152,15 @@ impl Protocols {
         p.add(Box::new(OregonV3));
         p.add(Box::new(X10Rf));
         p.add(Box::new(Ev1527));
+        p.add(Box::new(Princeton));
+        p.add(Box::new(Holtek));
+        p.add(Box::new(HoltekHt12x));
+        p.add(Box::new(Ansonic));
+        p.add(Box::new(Bett));
+        p.add(Box::new(came12_bit()));
+        p.add(Box::new(came24_bit()));
+        p.add(Box::new(NiceFlo));
+        p.add(Box::new(Linear));
         p
     }
 

--- a/crates/decode/src/protocols/keyfob/ansonic.rs
+++ b/crates/decode/src/protocols/keyfob/ansonic.rs
@@ -10,7 +10,7 @@
 
 use crate::bits::BitBuffer;
 use crate::protocol::{DecodeError, Protocol, Report};
-use crate::protocols::keyfob::shared::{find_and_parse, pwm};
+use crate::protocols::keyfob::shared::{find_and_parse, plausible, pwm};
 use crate::slicer::Timing;
 
 pub struct Ansonic;
@@ -30,6 +30,9 @@ impl Protocol for Ansonic {
         // Note: no inversion. Ansonic sends short-mark 1.
         find_and_parse(bits, FRAME_BITS, false, |b| {
             let code = ((b[0] as u16) << 4) | (b[1] as u16 >> 4);
+            if !plausible(code as u64, FRAME_BITS as u32) {
+                return None;
+            }
             let mut r = Report::new("Ansonic");
             r.crc_valid = None;
             r.raw = b[..2].to_vec();

--- a/crates/decode/src/protocols/keyfob/ansonic.rs
+++ b/crates/decode/src/protocols/keyfob/ansonic.rs
@@ -1,0 +1,67 @@
+//! Ansonic: a 12-bit fixed-code remote whose short mark is a `1` and long
+//! mark a `0`, the same polarity super-radio's slicer already produces, so
+//! (unlike most keyfobs) the frame is found without inversion.
+//!
+//! ```text
+//! 10101010 1 01 0  k
+//! ```
+//! The low 11 bits are the DIP-switch address, with the button in bits 1-2:
+//! `cnt = code & 0xfff`, `btn = (code >> 1) & 0x3`.
+
+use crate::bits::BitBuffer;
+use crate::protocol::{DecodeError, Protocol, Report};
+use crate::protocols::keyfob::shared::{find_and_parse, pwm};
+use crate::slicer::Timing;
+
+pub struct Ansonic;
+
+const FRAME_BITS: usize = 12;
+
+impl Protocol for Ansonic {
+    fn name(&self) -> &'static str {
+        "Ansonic"
+    }
+
+    fn timing(&self) -> Timing {
+        pwm(555, 1111, 2500)
+    }
+
+    fn decode(&self, bits: &BitBuffer) -> Result<Report, DecodeError> {
+        // Note: no inversion. Ansonic sends short-mark 1.
+        find_and_parse(bits, FRAME_BITS, false, |b| {
+            let code = ((b[0] as u16) << 4) | (b[1] as u16 >> 4);
+            let mut r = Report::new("Ansonic");
+            r.crc_valid = None;
+            r.raw = b[..2].to_vec();
+            Some(
+                r.int("code", code as i64)
+                    .int("cnt", (code & 0xfff) as i64)
+                    .int("btn", ((code >> 1) & 0x3) as i64),
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bits::BitBuffer;
+    use crate::protocol::Value;
+
+    /// No inversion: decode input is the on-air frame as-is.
+    fn input(code: u16) -> BitBuffer {
+        let mut b = BitBuffer::new();
+        for i in 0..FRAME_BITS {
+            b.push(code & (1 << (FRAME_BITS - 1 - i)) != 0);
+        }
+        b
+    }
+
+    #[test]
+    fn decodes_a_key_press() {
+        // btn = bits 1-2 of 0x123.
+        let r = Ansonic.decode(&input(0x123)).unwrap();
+        assert_eq!(r.get("cnt"), Some(&Value::Int(0x123)));
+        assert_eq!(r.get("btn"), Some(&Value::Int(0x123 >> 1 & 0x3)));
+    }
+}

--- a/crates/decode/src/protocols/keyfob/bett.rs
+++ b/crates/decode/src/protocols/keyfob/bett.rs
@@ -10,7 +10,7 @@
 
 use crate::bits::BitBuffer;
 use crate::protocol::{DecodeError, Protocol, Report};
-use crate::protocols::keyfob::shared::{find_and_parse, pwm};
+use crate::protocols::keyfob::shared::{find_and_parse, plausible, pwm};
 use crate::slicer::Timing;
 
 pub struct Bett;
@@ -29,6 +29,9 @@ impl Protocol for Bett {
     fn decode(&self, bits: &BitBuffer) -> Result<Report, DecodeError> {
         find_and_parse(bits, FRAME_BITS, true, |b| {
             let code = (b[0] as u32) << 10 | (b[1] as u32) << 2 | (b[2] as u32 >> 6);
+            if !plausible(code as u64, FRAME_BITS as u32) {
+                return None;
+            }
             let mut r = Report::new("Bett");
             r.crc_valid = None;
             r.raw = b[..3].to_vec();

--- a/crates/decode/src/protocols/keyfob/bett.rs
+++ b/crates/decode/src/protocols/keyfob/bett.rs
@@ -1,0 +1,60 @@
+//! Bett: an 18-bit fixed-code gate remote (BETT, and the Italian gate makers
+//! that share its chipset).
+//!
+//! A short mark (340 us) is a `0` and a long mark (2000 us) is a `1`, so the
+//! frame is found on the inverted buffer. There is no checksum, no serial and
+//! no button split: the whole 18-bit code is a fixed address set in the fob,
+//! and the DIP-switch pattern on the receiver is derived from it. The burst
+//! detector splits the long guard gap between frames, so each package is one
+//! frame.
+
+use crate::bits::BitBuffer;
+use crate::protocol::{DecodeError, Protocol, Report};
+use crate::protocols::keyfob::shared::{find_and_parse, pwm};
+use crate::slicer::Timing;
+
+pub struct Bett;
+
+const FRAME_BITS: usize = 18;
+
+impl Protocol for Bett {
+    fn name(&self) -> &'static str {
+        "Bett"
+    }
+
+    fn timing(&self) -> Timing {
+        pwm(340, 2000, 15000)
+    }
+
+    fn decode(&self, bits: &BitBuffer) -> Result<Report, DecodeError> {
+        find_and_parse(bits, FRAME_BITS, true, |b| {
+            let code = (b[0] as u32) << 10 | (b[1] as u32) << 2 | (b[2] as u32 >> 6);
+            let mut r = Report::new("Bett");
+            r.crc_valid = None;
+            r.raw = b[..3].to_vec();
+            Some(r.int("code", code as i64))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bits::BitBuffer;
+    use crate::protocol::Value;
+
+    fn input(code: u32) -> BitBuffer {
+        let mut b = BitBuffer::new();
+        for i in 0..FRAME_BITS {
+            b.push(code & (1 << (FRAME_BITS - 1 - i)) != 0);
+        }
+        b.inverted()
+    }
+
+    #[test]
+    fn decodes_a_gate_code() {
+        let r = Bett.decode(&input(0x3abcd)).unwrap();
+        assert_eq!(r.get("code"), Some(&Value::Int(0x3abcd)));
+        assert_eq!(r.crc_valid, None);
+    }
+}

--- a/crates/decode/src/protocols/keyfob/came.rs
+++ b/crates/decode/src/protocols/keyfob/came.rs
@@ -1,0 +1,93 @@
+//! CAME: the Spanish gate-and-remote maker's fixed-code fobs, in 12-bit and
+//! 24-bit forms (plus, on the same timing, AirForce and PRASTEL which the
+//! Flipper detects from the frame length; only the two CAME lengths are
+//! registered here).
+//!
+//! A short mark is a `0` and a long mark a `1`, so frames are found on the
+//! inverted buffer. There is no checksum: the frame length and its repeats
+//! are the only integrity check. One decoder struct, two registered
+//! instances differing only in frame length, so the 24-bit frame is not also
+//! matched as two adjacent 12-bit halves.
+
+use crate::bits::BitBuffer;
+use crate::protocol::{DecodeError, Protocol, Report};
+use crate::protocols::keyfob::shared::{find_and_parse, pwm};
+use crate::slicer::Timing;
+
+pub struct Came {
+    name: &'static str,
+    frame_bits: usize,
+}
+
+/// CAME 12-bit fixed code.
+pub fn came12_bit() -> Came {
+    Came { name: "CAME-12bit", frame_bits: 12 }
+}
+
+/// CAME 24-bit fixed code.
+pub fn came24_bit() -> Came {
+    Came { name: "CAME-24bit", frame_bits: 24 }
+}
+
+impl Protocol for Came {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn timing(&self) -> Timing {
+        pwm(320, 640, 2500)
+    }
+
+    fn decode(&self, bits: &BitBuffer) -> Result<Report, DecodeError> {
+        let fb = self.frame_bits;
+        find_and_parse(bits, fb, true, |b| {
+            let code = if fb == 12 {
+                ((b[0] as u32) << 4) | (b[1] as u32 >> 4)
+            } else {
+                (b[0] as u32) << 16 | (b[1] as u32) << 8 | b[2] as u32
+            };
+            if code == 0 {
+                return None;
+            }
+            let mut r = Report::new(self.name);
+            r.crc_valid = None;
+            r.raw = b.to_vec();
+            Some(r.int("code", code as i64))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bits::BitBuffer;
+    use crate::protocol::Value;
+
+    fn input(fb: usize, code: u32) -> BitBuffer {
+        let mut b = BitBuffer::new();
+        for i in 0..fb {
+            b.push(code & (1 << (fb - 1 - i)) != 0);
+        }
+        b.inverted()
+    }
+
+    #[test]
+    fn decodes_a_12bit_frame() {
+        let r = came12_bit().decode(&input(12, 0xabc)).unwrap();
+        assert_eq!(r.get("code"), Some(&Value::Int(0xabc)));
+        assert_eq!(r.crc_valid, None);
+    }
+
+    #[test]
+    fn decodes_a_24bit_frame() {
+        let r = came24_bit().decode(&input(24, 0xabc_def)).unwrap();
+        assert_eq!(r.get("code"), Some(&Value::Int(0xabc_def)));
+    }
+
+    #[test]
+    fn a_12bit_decoder_does_not_swallow_a_24bit_frame() {
+        // Two 12-bit halves both decode, but the 24-bit frame does not match
+        // the 12-bit frame length with corroboration.
+        assert_eq!(came12_bit().decode(&input(24, 0xabc_def)), Err(DecodeError::NotThisProtocol));
+    }
+}

--- a/crates/decode/src/protocols/keyfob/came.rs
+++ b/crates/decode/src/protocols/keyfob/came.rs
@@ -11,7 +11,7 @@
 
 use crate::bits::BitBuffer;
 use crate::protocol::{DecodeError, Protocol, Report};
-use crate::protocols::keyfob::shared::{find_and_parse, pwm};
+use crate::protocols::keyfob::shared::{find_and_parse, plausible, pwm};
 use crate::slicer::Timing;
 
 pub struct Came {
@@ -46,7 +46,7 @@ impl Protocol for Came {
             } else {
                 (b[0] as u32) << 16 | (b[1] as u32) << 8 | b[2] as u32
             };
-            if code == 0 {
+            if !plausible(code as u64, fb as u32) {
                 return None;
             }
             let mut r = Report::new(self.name);

--- a/crates/decode/src/protocols/keyfob/holtek.rs
+++ b/crates/decode/src/protocols/keyfob/holtek.rs
@@ -18,7 +18,7 @@
 
 use crate::bits::BitBuffer;
 use crate::protocol::{DecodeError, Protocol, Report};
-use crate::protocols::keyfob::shared::{find_and_parse, pwm, reverse_key};
+use crate::protocols::keyfob::shared::{find_and_parse, plausible, pwm, reverse_key};
 use crate::slicer::Timing;
 
 pub struct Holtek;
@@ -43,7 +43,7 @@ impl Protocol for Holtek {
                 | (b[2] as u64) << 16
                 | (b[3] as u64) << 8
                 | b[4] as u64;
-            if data & HEADER_MASK != HEADER {
+            if data & HEADER_MASK != HEADER || !plausible(data, FRAME_BITS as u32) {
                 return None;
             }
             // Serial is the 20 bits under the header, sent LSB first.

--- a/crates/decode/src/protocols/keyfob/holtek.rs
+++ b/crates/decode/src/protocols/keyfob/holtek.rs
@@ -1,0 +1,117 @@
+//! Holtek (HT6P20/HT6P30B family): 40-bit fixed-code remotes, one of the most
+//! common doorbell and gate fobs in Asia and Europe.
+//!
+//! A short mark is a 0 and a long mark is a 1 (inverted from the slicer), so
+//! the frame is found on the inverted buffer. The 40 bits are:
+//!
+//! ```text
+//! HHHH SSSS SSSS SSSS SSSS BBBB BBBB BBBB BBBB
+//! ```
+//!
+//! - `H` 4-bit header, always `0x5`, which is what pins the frame's alignment
+//! - `S` 20-bit serial, transmitted least-significant-bit first
+//! - `B` 16 bits as four 4-bit button nibbles, every one `0xA` except the
+//!   nibble belonging to the pressed button
+//!
+//! There is no checksum. The header and the repeat corroboration are the only
+//! integrity check, which is what the Flipper relies on too.
+
+use crate::bits::BitBuffer;
+use crate::protocol::{DecodeError, Protocol, Report};
+use crate::protocols::keyfob::shared::{find_and_parse, pwm, reverse_key};
+use crate::slicer::Timing;
+
+pub struct Holtek;
+
+const FRAME_BITS: usize = 40;
+const HEADER_MASK: u64 = 0xf000_0000_00;
+const HEADER: u64 = 0x5000_0000_00;
+
+impl Protocol for Holtek {
+    fn name(&self) -> &'static str {
+        "Holtek"
+    }
+
+    fn timing(&self) -> Timing {
+        pwm(430, 870, 4000)
+    }
+
+    fn decode(&self, bits: &BitBuffer) -> Result<Report, DecodeError> {
+        find_and_parse(bits, FRAME_BITS, true, |b| {
+            let data = (b[0] as u64) << 32
+                | (b[1] as u64) << 24
+                | (b[2] as u64) << 16
+                | (b[3] as u64) << 8
+                | b[4] as u64;
+            if data & HEADER_MASK != HEADER {
+                return None;
+            }
+            // Serial is the 20 bits under the header, sent LSB first.
+            let serial = reverse_key((data >> 16) & 0xfffff, 20);
+            // Four 4-bit button nibbles in the low 16 bits; all read 0xA
+            // except the pressed one, whose index is the button number.
+            let btn = match (data & 0xffff) as u16 {
+                n if n & 0xf != 0xa => 1,
+                n if (n >> 4) & 0xf != 0xa => 2,
+                n if (n >> 8) & 0xf != 0xa => 3,
+                n if (n >> 12) & 0xf != 0xa => 4,
+                _ => return None,
+            };
+            let mut r = Report::new("Holtek");
+            r.crc_valid = None;
+            r.raw = b.to_vec();
+            Some(r.int("code", data as i64).int("serial", serial as i64).int("btn", btn))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bits::BitBuffer;
+    use crate::protocol::Value;
+
+    fn on_air(header: u8, serial: u64, pressed_nibble: u8) -> u64 {
+        // Four nibbles all 0xa except the pressed one.
+        let nibbles: [u8; 4] = [pressed_nibble, 0xa, 0xa, 0xa];
+        let mut btn_field = 0u64;
+        for (i, n) in nibbles.iter().enumerate() {
+            btn_field |= (*n as u64) << (i * 4);
+        }
+        // Serial is transmitted LSB first, so it goes on the wire reversed
+        // and the decoder reverses it back to `serial`.
+        let data = (header as u64) << 36 | reverse_key(serial, 20) << 16 | btn_field;
+        data
+    }
+
+    /// Build decode input: invert the on-air frame.
+    fn input(data: u64) -> BitBuffer {
+        let mut b = BitBuffer::new();
+        for i in 0..FRAME_BITS {
+            b.push(data & (1 << (FRAME_BITS - 1 - i)) != 0);
+        }
+        b.inverted()
+    }
+
+    #[test]
+    fn decodes_a_key_press() {
+        // serial 0x12345 transmitted LSB first -> reverse_key makes it back.
+        let data = on_air(0x5, 0x12345, 0x1);
+        let r = Holtek.decode(&input(data)).unwrap();
+        assert_eq!(r.get("serial"), Some(&Value::Int(0x12345)));
+        assert_eq!(r.get("btn"), Some(&Value::Int(1)));
+        assert_eq!(r.crc_valid, None);
+    }
+
+    #[test]
+    fn a_wrong_header_is_not_this_protocol() {
+        assert_eq!(Holtek.decode(&input(on_air(0x7, 0x12345, 0x1))), Err(DecodeError::NotThisProtocol));
+    }
+
+    #[test]
+    fn no_button_nibble_means_reject() {
+        // All four nibbles 0xa: no button pressed, so no valid frame.
+        let data = 0x5000_0000_00 | (0x12345u64 << 16) | 0xaaaa;
+        assert_eq!(Holtek.decode(&input(data)), Err(DecodeError::NotThisProtocol));
+    }
+}

--- a/crates/decode/src/protocols/keyfob/holtek_ht12x.rs
+++ b/crates/decode/src/protocols/keyfob/holtek_ht12x.rs
@@ -1,0 +1,74 @@
+//! Holtek HT12x (HT12D/HT12E): 12-bit fixed-code remotes, the smallest fob
+//! format the Flipper supports.
+//!
+//! A short mark is a 0 and a long mark is a 1 (inverted from the slicer). The
+//! 12-bit code splits as an 8-bit serial/address and a 4-bit button:
+//!
+//! ```text
+//! AAAA AAAA BBBB
+//! ```
+
+use crate::bits::BitBuffer;
+use crate::protocol::{DecodeError, Protocol, Report};
+use crate::protocols::keyfob::shared::{find_and_parse, pwm};
+use crate::slicer::Timing;
+
+pub struct HoltekHt12x;
+
+const FRAME_BITS: usize = 12;
+
+impl Protocol for HoltekHt12x {
+    fn name(&self) -> &'static str {
+        "Holtek-HT12x"
+    }
+
+    fn timing(&self) -> Timing {
+        pwm(320, 640, 2500)
+    }
+
+    fn decode(&self, bits: &BitBuffer) -> Result<Report, DecodeError> {
+        find_and_parse(bits, FRAME_BITS, true, |b| {
+            let code = ((b[0] as u16) << 4) | (b[1] as u16 >> 4);
+            if code == 0 {
+                return None;
+            }
+            let mut r = Report::new("Holtek-HT12x");
+            r.crc_valid = None;
+            r.raw = b[..2].to_vec();
+            Some(
+                r.int("code", code as i64)
+                    .int("serial", ((code >> 4) & 0xff) as i64)
+                    .int("btn", (code & 0xf) as i64),
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bits::BitBuffer;
+    use crate::protocol::Value;
+
+    fn input(code: u16) -> BitBuffer {
+        let mut b = BitBuffer::new();
+        for i in 0..FRAME_BITS {
+            b.push(code & (1 << (FRAME_BITS - 1 - i)) != 0);
+        }
+        b.inverted()
+    }
+
+    #[test]
+    fn decodes_a_key_press() {
+        let r = HoltekHt12x.decode(&input(0xabc)).unwrap();
+        assert_eq!(r.get("code"), Some(&Value::Int(0xabc)));
+        assert_eq!(r.get("serial"), Some(&Value::Int(0xab)));
+        assert_eq!(r.get("btn"), Some(&Value::Int(0xc)));
+        assert_eq!(r.crc_valid, None);
+    }
+
+    #[test]
+    fn a_zero_code_is_rejected() {
+        assert_eq!(HoltekHt12x.decode(&input(0)), Err(DecodeError::NotThisProtocol));
+    }
+}

--- a/crates/decode/src/protocols/keyfob/holtek_ht12x.rs
+++ b/crates/decode/src/protocols/keyfob/holtek_ht12x.rs
@@ -10,7 +10,7 @@
 
 use crate::bits::BitBuffer;
 use crate::protocol::{DecodeError, Protocol, Report};
-use crate::protocols::keyfob::shared::{find_and_parse, pwm};
+use crate::protocols::keyfob::shared::{find_and_parse, plausible, pwm};
 use crate::slicer::Timing;
 
 pub struct HoltekHt12x;
@@ -29,7 +29,7 @@ impl Protocol for HoltekHt12x {
     fn decode(&self, bits: &BitBuffer) -> Result<Report, DecodeError> {
         find_and_parse(bits, FRAME_BITS, true, |b| {
             let code = ((b[0] as u16) << 4) | (b[1] as u16 >> 4);
-            if code == 0 {
+            if !plausible(code as u64, FRAME_BITS as u32) {
                 return None;
             }
             let mut r = Report::new("Holtek-HT12x");

--- a/crates/decode/src/protocols/keyfob/linear.rs
+++ b/crates/decode/src/protocols/keyfob/linear.rs
@@ -9,7 +9,7 @@
 
 use crate::bits::BitBuffer;
 use crate::protocol::{DecodeError, Protocol, Report};
-use crate::protocols::keyfob::shared::{find_and_parse, pwm};
+use crate::protocols::keyfob::shared::{find_and_parse, plausible, pwm};
 use crate::slicer::Timing;
 
 pub struct Linear;
@@ -28,7 +28,7 @@ impl Protocol for Linear {
     fn decode(&self, bits: &BitBuffer) -> Result<Report, DecodeError> {
         find_and_parse(bits, FRAME_BITS, true, |b| {
             let data = ((b[0] as u16) << 2) | (b[1] as u16 >> 6);
-            if data == 0 {
+            if !plausible(data as u64, FRAME_BITS as u32) {
                 return None;
             }
             // The collected bits are inverted relative to the printed key.

--- a/crates/decode/src/protocols/keyfob/linear.rs
+++ b/crates/decode/src/protocols/keyfob/linear.rs
@@ -1,0 +1,66 @@
+//! Linear: a 10-bit fixed-code remote (Linear 3089 and the DIP-switch
+//! remotes that share its chip).
+//!
+//! A short mark is a `0` and a long mark a `1`, so the frame is found on the
+//! inverted buffer. The Flipper notes the decoder collects the code
+//! inverted relative to the label, and its display flips it back: the value
+//! that matches a receiver's DIP switches is `!data & 0x3ff`, which is what
+//! this reports as `code`.
+
+use crate::bits::BitBuffer;
+use crate::protocol::{DecodeError, Protocol, Report};
+use crate::protocols::keyfob::shared::{find_and_parse, pwm};
+use crate::slicer::Timing;
+
+pub struct Linear;
+
+const FRAME_BITS: usize = 10;
+
+impl Protocol for Linear {
+    fn name(&self) -> &'static str {
+        "Linear"
+    }
+
+    fn timing(&self) -> Timing {
+        pwm(500, 1500, 2500)
+    }
+
+    fn decode(&self, bits: &BitBuffer) -> Result<Report, DecodeError> {
+        find_and_parse(bits, FRAME_BITS, true, |b| {
+            let data = ((b[0] as u16) << 2) | (b[1] as u16 >> 6);
+            if data == 0 {
+                return None;
+            }
+            // The collected bits are inverted relative to the printed key.
+            let code = !data & 0x3ff;
+            let mut r = Report::new("Linear");
+            r.crc_valid = None;
+            r.raw = b[..2].to_vec();
+            Some(r.int("code", code as i64).int("raw", data as i64))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bits::BitBuffer;
+    use crate::protocol::Value;
+
+    fn input(code: u16) -> BitBuffer {
+        let mut b = BitBuffer::new();
+        for i in 0..FRAME_BITS {
+            b.push(code & (1 << (FRAME_BITS - 1 - i)) != 0);
+        }
+        b.inverted()
+    }
+
+    #[test]
+    fn decodes_a_dip_switch_code() {
+        // On-air data 0x155 inverts to the printed key 0x2aa.
+        let r = Linear.decode(&input(0x155)).unwrap();
+        assert_eq!(r.get("code"), Some(&Value::Int(0x2aa)));
+        assert_eq!(r.get("raw"), Some(&Value::Int(0x155)));
+        assert_eq!(r.crc_valid, None);
+    }
+}

--- a/crates/decode/src/protocols/keyfob/linear_delta3.rs
+++ b/crates/decode/src/protocols/keyfob/linear_delta3.rs
@@ -1,0 +1,62 @@
+//! Linear Delta3: an 8-bit rolling-code remote whose short mark is a `1` and
+//! long mark a `0`, the same polarity as the slicer, so the frame is found
+//! without inversion (the opposite of the fixed-code Linear above).
+//!
+//! The 8-bit code is a per-press counter the receiver compares against a
+//! window; this decoder surfaces the counter, which is all a receiver without
+//! the learned key can do with a rolling code.
+
+use crate::bits::BitBuffer;
+use crate::protocol::{DecodeError, Protocol, Report};
+use crate::protocols::keyfob::shared::{find_and_parse, plausible, pwm};
+use crate::slicer::Timing;
+
+pub struct LinearDelta3;
+
+const FRAME_BITS: usize = 8;
+
+impl Protocol for LinearDelta3 {
+    fn name(&self) -> &'static str {
+        "Linear-Delta3"
+    }
+
+    fn timing(&self) -> Timing {
+        pwm(500, 2000, 4000)
+    }
+
+    fn decode(&self, bits: &BitBuffer) -> Result<Report, DecodeError> {
+        // No inversion: Delta3 sends short-mark 1.
+        find_and_parse(bits, FRAME_BITS, false, |b| {
+            let code = b[0];
+            if !plausible(code as u64, FRAME_BITS as u32) {
+                return None;
+            }
+            let mut r = Report::new("Linear-Delta3");
+            r.crc_valid = None;
+            r.raw = b[..1].to_vec();
+            Some(r.int("cnt", code as i64))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bits::BitBuffer;
+    use crate::protocol::Value;
+
+    fn input(code: u8) -> BitBuffer {
+        let mut b = BitBuffer::new();
+        for i in 0..FRAME_BITS {
+            b.push(code & (1 << (FRAME_BITS - 1 - i)) != 0);
+        }
+        b
+    }
+
+    #[test]
+    fn decodes_a_counter_value() {
+        let r = LinearDelta3.decode(&input(0x5a)).unwrap();
+        assert_eq!(r.get("cnt"), Some(&Value::Int(0x5a)));
+        assert_eq!(r.crc_valid, None);
+    }
+}

--- a/crates/decode/src/protocols/keyfob/mod.rs
+++ b/crates/decode/src/protocols/keyfob/mod.rs
@@ -24,6 +24,7 @@ mod came;
 mod holtek;
 mod holtek_ht12x;
 mod linear;
+mod linear_delta3;
 mod nice_flo;
 mod princeton;
 
@@ -33,5 +34,6 @@ pub use came::{came12_bit, came24_bit};
 pub use holtek::Holtek;
 pub use holtek_ht12x::HoltekHt12x;
 pub use linear::Linear;
+pub use linear_delta3::LinearDelta3;
 pub use nice_flo::NiceFlo;
 pub use princeton::Princeton;

--- a/crates/decode/src/protocols/keyfob/mod.rs
+++ b/crates/decode/src/protocols/keyfob/mod.rs
@@ -1,0 +1,37 @@
+//! Keyfob remote-control protocols ported from the Flipper Zero firmware
+//! (Momentum-Firmware, `lib/subghz/protocols`).
+//!
+//! These are the remotes you find on garage doors, gates and car alarm
+//! fobs: short OOK PWM frames on 315/433/868 MHz with no checksum (so the
+//! frame's own repeat count is the integrity check), or a rolling code whose
+//! counter rolls on every press. They differ from the sensor protocols in
+//! `..` only in being keyed by a button rather than a measurement.
+//!
+//! `shared` holds the helpers: a Flipper-style timing table constructor, the
+//! bit-reversal the Flipper applies to several serial numbers, and
+//! `find_and_parse`, the invert-and-search used by every fixed-code remote.
+//!
+//! Frame layouts and timings are transcribed from the Flipper's own
+//! `SubGhzBlockConst` and decoder state machines; where a decoder reads the
+//! opposite bit polarity from super-radio's slicer, `find_and_parse` is told
+//! to invert.
+
+pub mod shared;
+
+mod ansonic;
+mod bett;
+mod came;
+mod holtek;
+mod holtek_ht12x;
+mod linear;
+mod nice_flo;
+mod princeton;
+
+pub use ansonic::Ansonic;
+pub use bett::Bett;
+pub use came::{came12_bit, came24_bit};
+pub use holtek::Holtek;
+pub use holtek_ht12x::HoltekHt12x;
+pub use linear::Linear;
+pub use nice_flo::NiceFlo;
+pub use princeton::Princeton;

--- a/crates/decode/src/protocols/keyfob/nice_flo.rs
+++ b/crates/decode/src/protocols/keyfob/nice_flo.rs
@@ -6,7 +6,7 @@
 
 use crate::bits::BitBuffer;
 use crate::protocol::{DecodeError, Protocol, Report};
-use crate::protocols::keyfob::shared::{find_and_parse, pwm};
+use crate::protocols::keyfob::shared::{find_and_parse, plausible, pwm};
 use crate::slicer::Timing;
 
 pub struct NiceFlo;
@@ -25,7 +25,7 @@ impl Protocol for NiceFlo {
     fn decode(&self, bits: &BitBuffer) -> Result<Report, DecodeError> {
         find_and_parse(bits, FRAME_BITS, true, |b| {
             let code = ((b[0] as u16) << 4) | (b[1] as u16 >> 4);
-            if code == 0 {
+            if !plausible(code as u64, FRAME_BITS as u32) {
                 return None;
             }
             let mut r = Report::new("Nice-Flo");

--- a/crates/decode/src/protocols/keyfob/nice_flo.rs
+++ b/crates/decode/src/protocols/keyfob/nice_flo.rs
@@ -1,0 +1,59 @@
+//! Nice FLO: an Italian gate remote's 12-bit fixed code (the newer FLO2/FLOR
+//! rolling codes live under their own names).
+//!
+//! A short mark is a `0` and a long mark a `1`, so the frame is found on the
+//! inverted buffer. No checksum; the frame length and repeats corroborate.
+
+use crate::bits::BitBuffer;
+use crate::protocol::{DecodeError, Protocol, Report};
+use crate::protocols::keyfob::shared::{find_and_parse, pwm};
+use crate::slicer::Timing;
+
+pub struct NiceFlo;
+
+const FRAME_BITS: usize = 12;
+
+impl Protocol for NiceFlo {
+    fn name(&self) -> &'static str {
+        "Nice-Flo"
+    }
+
+    fn timing(&self) -> Timing {
+        pwm(700, 1400, 3000)
+    }
+
+    fn decode(&self, bits: &BitBuffer) -> Result<Report, DecodeError> {
+        find_and_parse(bits, FRAME_BITS, true, |b| {
+            let code = ((b[0] as u16) << 4) | (b[1] as u16 >> 4);
+            if code == 0 {
+                return None;
+            }
+            let mut r = Report::new("Nice-Flo");
+            r.crc_valid = None;
+            r.raw = b[..2].to_vec();
+            Some(r.int("code", code as i64))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bits::BitBuffer;
+    use crate::protocol::Value;
+
+    fn input(code: u16) -> BitBuffer {
+        let mut b = BitBuffer::new();
+        for i in 0..FRAME_BITS {
+            b.push(code & (1 << (FRAME_BITS - 1 - i)) != 0);
+        }
+        b.inverted()
+    }
+
+    #[test]
+    fn decodes_a_gate_code() {
+        let r = NiceFlo.decode(&input(0xabc)).unwrap();
+        assert_eq!(r.get("code"), Some(&Value::Int(0xabc)));
+        assert_eq!(r.crc_valid, None);
+    }
+}

--- a/crates/decode/src/protocols/keyfob/princeton.rs
+++ b/crates/decode/src/protocols/keyfob/princeton.rs
@@ -1,0 +1,108 @@
+//! Princeton (also the 24-bit "Generic" fixed-code remote many clone it
+//! from): the commonest garage-door keyfob on 433.92 MHz.
+//!
+//! A short mark is a 0 and a long mark is a 1, transmitted as a burst of
+//! identical 24-bit frames behind a ~14 ms preamble. There is no checksum of
+//! any kind, so the decoder reports `crc_valid: None` and relies on the
+//! frame's repeat count (the corroboration in `find_and_parse`) to tell a
+//! real remote from a burst that happens to decode. The 24-bit code splits as
+//! 20-bit serial and 4-bit button for the common remotes; a few use one of
+//! four 8-bit button codes in the low byte, which the Flipper detects and
+//! reports as an 8-bit button. The serial/button split is shown here the same
+//! way the Flipper's `check_remote_controller` does.
+
+use crate::bits::BitBuffer;
+use crate::protocol::{DecodeError, Protocol, Report};
+use crate::protocols::keyfob::shared::{find_and_parse, pwm};
+use crate::slicer::Timing;
+
+/// A Princeton 24-bit fixed-code remote.
+pub struct Princeton;
+
+const FRAME_BITS: usize = 24;
+
+impl Protocol for Princeton {
+    fn name(&self) -> &'static str {
+        "Princeton"
+    }
+
+    fn timing(&self) -> Timing {
+        pwm(390, 1170, 3000)
+    }
+
+    fn decode(&self, bits: &BitBuffer) -> Result<Report, DecodeError> {
+        find_and_parse(bits, FRAME_BITS, true, |b| {
+            // 24-bit code, MSB first, short-mark-0 on the air.
+            let code = (b[0] as u32) << 16 | (b[1] as u32) << 8 | b[2] as u32;
+            if code == 0 {
+                return None;
+            }
+            let (serial, btn) = match code & 0xff {
+                // Second encoding: an 8-bit button code in the low byte.
+                0x30 | 0xc0 => (code >> 8, code & 0xff),
+                // Button codes 0x03/0x0c read as zero-leading; fix them up.
+                0x03 | 0x0c => (code >> 8, (code & 0xff) | 0xf0),
+                _ => (code >> 4, code & 0xf),
+            };
+            let mut r = Report::new("Princeton");
+            r.crc_valid = None;
+            r.raw = b.to_vec();
+            Some(
+                r.int("code", code as i64)
+                    .int("serial", serial as i64)
+                    .int("btn", btn as i64),
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bits::BitBuffer;
+    use crate::protocol::Value;
+
+    /// Build decode input for an on-air 24-bit code: the slicer inverts, so
+    /// the frame goes in inverted.
+    fn input(code: u32) -> BitBuffer {
+        let mut b = BitBuffer::new();
+        for i in 0..FRAME_BITS {
+            b.push(code & (1 << (FRAME_BITS - 1 - i)) != 0);
+        }
+        b.inverted()
+    }
+
+    #[test]
+    fn decodes_a_remote_press() {
+        let r = Princeton.decode(&input(0xa1_3f_08)).unwrap();
+        assert_eq!(r.get("code"), Some(&Value::Int(0xa13f08)));
+        assert_eq!(r.get("serial"), Some(&Value::Int(0xa13f0)));
+        assert_eq!(r.get("btn"), Some(&Value::Int(0x8)));
+        assert_eq!(r.crc_valid, None);
+    }
+
+    #[test]
+    fn finds_the_frame_among_repeats() {
+        // Three identical frames back to back, as a real burst sends.
+        let mut b = BitBuffer::new();
+        for _ in 0..3 {
+            for i in 0..FRAME_BITS {
+                b.push(0xa1_3f_08 & (1 << (FRAME_BITS - 1 - i)) != 0);
+            }
+        }
+        let r = Princeton.decode(&b.inverted()).unwrap();
+        assert_eq!(r.get("code"), Some(&Value::Int(0xa13f08)));
+    }
+
+    #[test]
+    fn an_8bit_button_code_is_reported_as_such() {
+        let r = Princeton.decode(&input(0x1234_c0)).unwrap();
+        assert_eq!(r.get("serial"), Some(&Value::Int(0x1234)));
+        assert_eq!(r.get("btn"), Some(&Value::Int(0xc0)));
+    }
+
+    #[test]
+    fn a_zero_code_is_not_this_protocol() {
+        assert_eq!(Princeton.decode(&input(0)), Err(DecodeError::NotThisProtocol));
+    }
+}

--- a/crates/decode/src/protocols/keyfob/princeton.rs
+++ b/crates/decode/src/protocols/keyfob/princeton.rs
@@ -13,7 +13,7 @@
 
 use crate::bits::BitBuffer;
 use crate::protocol::{DecodeError, Protocol, Report};
-use crate::protocols::keyfob::shared::{find_and_parse, pwm};
+use crate::protocols::keyfob::shared::{find_and_parse, plausible, pwm};
 use crate::slicer::Timing;
 
 /// A Princeton 24-bit fixed-code remote.
@@ -34,7 +34,7 @@ impl Protocol for Princeton {
         find_and_parse(bits, FRAME_BITS, true, |b| {
             // 24-bit code, MSB first, short-mark-0 on the air.
             let code = (b[0] as u32) << 16 | (b[1] as u32) << 8 | b[2] as u32;
-            if code == 0 {
+            if !plausible(code as u64, FRAME_BITS as u32) {
                 return None;
             }
             let (serial, btn) = match code & 0xff {

--- a/crates/decode/src/protocols/keyfob/shared.rs
+++ b/crates/decode/src/protocols/keyfob/shared.rs
@@ -11,8 +11,18 @@
 
 use crate::bits::BitBuffer;
 use crate::protocol::{DecodeError, Report};
-use crate::protocols::find_frame_bits;
 use crate::slicer::{Coding, Timing};
+
+/// How many bits a single-frame package may exceed the frame by before it is
+/// no longer treated as one frame and must show a repeat instead.
+///
+/// A real reception is one frame plus maybe a leading start bit and a little
+/// slicer slop. The Flipper's streaming decoders count the start bit out of
+/// the frame, but the slicer does not know it is a start bit, so it becomes a
+/// bit here. Allowing a few bits of slop covers that; a burst twice as long
+/// as the frame (which is what a mis-sliced other-protocol signal looks
+/// like) is refused until it shows the same frame twice.
+const ALONE_SLOP: usize = 8;
 
 /// Build a PWM timing table from a Flipper `SubGhzBlockConst`.
 ///
@@ -28,20 +38,20 @@ pub fn pwm(short_us: u32, long_us: u32, reset_us: u32) -> Timing {
 /// `parse` produced for it.
 ///
 /// The slicer emits a short mark as `1` and a long mark as `0`. A Flipper
-/// protocol either reads the same way (Ansonic, CAME) or the opposite way
-/// (Princeton, Holtek, the rolling codes), which is what `invert` is for:
-/// pass `true` when the on-air convention is short-mark `0` / long-mark `1`.
-/// Either way, `parse` sees the on-air convention.
+/// protocol either reads the same way (Ansonic, Linear Delta3) or the
+/// opposite way (Princeton, Holtek, CAME, the rest), which is what `invert`
+/// is for: pass `true` when the on-air convention is short-mark `0` /
+/// long-mark `1`. Either way, `parse` sees the on-air convention.
 ///
-/// Corroboration (the identical frame again one frame later, or a short
-/// enough buffer that the detector's own framing agrees) is what stops a
-/// checksum-free protocol claiming every burst on the band; see
-/// [`find_frame_bits`].
+/// A checksum-free protocol has no integrity check to fall back on, so a
+/// match must be corroborated: either the identical frame appears again one
+/// frame later (what a real remote's repeat burst provides), or the package
+/// is short enough that it is plainly one frame rather than some other
+/// protocol's burst sliced at the wrong rate. That is the closest such a
+/// protocol comes to not claiming every burst on the band.
 ///
 /// `parse` is called once per candidate window with the zero-padded frame
-/// bytes and returns the report on success, `None` on any mismatch. The frame
-/// bytes are taken from the exact window `find_frame_bits` matched, which is
-/// why the search predicate and the parse share one closure.
+/// bytes and returns the report on success, `None` on any mismatch.
 pub fn find_and_parse(
     bits: &BitBuffer,
     frame_bits: usize,
@@ -49,9 +59,26 @@ pub fn find_and_parse(
     mut parse: impl FnMut(&[u8]) -> Option<Report>,
 ) -> Result<Report, DecodeError> {
     let bits = if invert { bits.inverted() } else { bits.clone() };
-    let b = find_frame_bits(&bits, frame_bits, |b| parse(b).is_some())
-        .ok_or(DecodeError::NotThisProtocol)?;
-    parse(&b).ok_or(DecodeError::NotThisProtocol)
+    let want = frame_bits;
+    if bits.len() < want {
+        return Err(DecodeError::NotThisProtocol);
+    }
+    let alone = bits.len() <= want + ALONE_SLOP;
+    for start in 0..=(bits.len() - want) {
+        let frame = bits.slice(start, want);
+        if !alone {
+            let repeated = |at: usize| bits.slice(at, want) == frame;
+            let corroborated = (start + 2 * want <= bits.len() && repeated(start + want))
+                || (start >= want && repeated(start - want));
+            if !corroborated {
+                continue;
+            }
+        }
+        if let Some(r) = parse(frame.as_padded_bytes()) {
+            return Ok(r);
+        }
+    }
+    Err(DecodeError::NotThisProtocol)
 }
 
 /// Reverse the order of the low `bits` of `value`, like the Flipper's
@@ -60,4 +87,18 @@ pub fn find_and_parse(
 /// printed label would use.
 pub fn reverse_key(value: u64, bits: u32) -> u64 {
     value.reverse_bits() >> (64 - bits)
+}
+
+/// True when `code` could be a real fixed-code frame rather than a burst of
+/// every bit the same.
+///
+/// A remote's DIP address is never constant, so an all-zero or all-one frame
+/// is how a no-checksum protocol misreads some other signal sliced at the
+/// wrong rate (a PPM weather sensor run through a keyfob's PWM timing comes
+/// out as a run of one symbol) or a piece of noise. Rejecting degenerate
+/// frames is the closest a checksum-free protocol comes to an integrity
+/// check, and it is what keeps it from claiming every monotonic burst on the
+/// band.
+pub fn plausible(code: u64, bits: u32) -> bool {
+    code != 0 && code != (1u64 << bits) - 1
 }

--- a/crates/decode/src/protocols/keyfob/shared.rs
+++ b/crates/decode/src/protocols/keyfob/shared.rs
@@ -1,0 +1,63 @@
+//! Shared machinery for keyfob remotes ported from the Flipper Zero firmware.
+//!
+//! Almost every fixed-code keyfob remote is PWM with a short mark for one
+//! symbol and a long mark for the other, transmitted as a short burst of
+//! identical frames behind a long preamble. The Flipper's streaming decoders
+//! each re-implement the same edge walker; here that is the slicer, and a
+//! protocol is a timing table plus a frame parser, exactly as for the sensor
+//! protocols. What the keyfobs add is polarity: the Flipper reads a short
+//! mark as `0` and a long mark as `1`, which is the opposite of what
+//! [`crate::slicer`] produces, so the whole buffer is inverted before parsing.
+
+use crate::bits::BitBuffer;
+use crate::protocol::{DecodeError, Report};
+use crate::protocols::find_frame_bits;
+use crate::slicer::{Coding, Timing};
+
+/// Build a PWM timing table from a Flipper `SubGhzBlockConst`.
+///
+/// `te_short`/`te_long` carry over unchanged. `reset_us` is the silence that
+/// separates one frame from the next; on the air it is the remote's guard
+/// time, and it is what lets the burst detector split a repeat train into
+/// frame-aligned packages.
+pub fn pwm(short_us: u32, long_us: u32, reset_us: u32) -> Timing {
+    Timing { coding: Coding::Pwm, short_us, long_us, sync_us: 0, tolerance_us: 0, reset_us }
+}
+
+/// Find a `frame_bits`-wide frame that `parse` accepts, then return what
+/// `parse` produced for it.
+///
+/// The slicer emits a short mark as `1` and a long mark as `0`. A Flipper
+/// protocol either reads the same way (Ansonic, CAME) or the opposite way
+/// (Princeton, Holtek, the rolling codes), which is what `invert` is for:
+/// pass `true` when the on-air convention is short-mark `0` / long-mark `1`.
+/// Either way, `parse` sees the on-air convention.
+///
+/// Corroboration (the identical frame again one frame later, or a short
+/// enough buffer that the detector's own framing agrees) is what stops a
+/// checksum-free protocol claiming every burst on the band; see
+/// [`find_frame_bits`].
+///
+/// `parse` is called once per candidate window with the zero-padded frame
+/// bytes and returns the report on success, `None` on any mismatch. The frame
+/// bytes are taken from the exact window `find_frame_bits` matched, which is
+/// why the search predicate and the parse share one closure.
+pub fn find_and_parse(
+    bits: &BitBuffer,
+    frame_bits: usize,
+    invert: bool,
+    mut parse: impl FnMut(&[u8]) -> Option<Report>,
+) -> Result<Report, DecodeError> {
+    let bits = if invert { bits.inverted() } else { bits.clone() };
+    let b = find_frame_bits(&bits, frame_bits, |b| parse(b).is_some())
+        .ok_or(DecodeError::NotThisProtocol)?;
+    parse(&b).ok_or(DecodeError::NotThisProtocol)
+}
+
+/// Reverse the order of the low `bits` of `value`, like the Flipper's
+/// `subghz_protocol_blocks_reverse_key`. Several remotes transmit their serial
+/// least-significant-bit first; this is what puts it back in the order a
+/// printed label would use.
+pub fn reverse_key(value: u64, bits: u32) -> u64 {
+    value.reverse_bits() >> (64 - bits)
+}

--- a/crates/decode/src/protocols/mod.rs
+++ b/crates/decode/src/protocols/mod.rs
@@ -26,7 +26,7 @@ pub use bresser::Bresser3Ch;
 pub use ev1527::Ev1527;
 pub use fineoffset::{FineOffsetWh1080, FineOffsetWh51};
 pub use globaltronics::{GtWt02, GtWt03};
-pub use keyfob::{Ansonic, Bett, came12_bit, came24_bit, Holtek, HoltekHt12x, Linear, NiceFlo, Princeton};
+pub use keyfob::{Ansonic, Bett, came12_bit, came24_bit, Holtek, HoltekHt12x, Linear, LinearDelta3, NiceFlo, Princeton};
 pub use lacrosse::{LacrosseIt, LacrosseTx141thBv2};
 pub use nexus::NexusTh;
 pub use oregon::OregonV3;

--- a/crates/decode/src/protocols/mod.rs
+++ b/crates/decode/src/protocols/mod.rs
@@ -14,6 +14,7 @@ mod bresser;
 mod ev1527;
 mod fineoffset;
 mod globaltronics;
+mod keyfob;
 mod lacrosse;
 mod nexus;
 mod oregon;
@@ -25,6 +26,7 @@ pub use bresser::Bresser3Ch;
 pub use ev1527::Ev1527;
 pub use fineoffset::{FineOffsetWh1080, FineOffsetWh51};
 pub use globaltronics::{GtWt02, GtWt03};
+pub use keyfob::{Ansonic, Bett, came12_bit, came24_bit, Holtek, HoltekHt12x, Linear, NiceFlo, Princeton};
 pub use lacrosse::{LacrosseIt, LacrosseTx141thBv2};
 pub use nexus::NexusTh;
 pub use oregon::OregonV3;
@@ -51,7 +53,7 @@ use crate::bits::BitBuffer;
 pub(crate) fn find_frame(
     bits: &BitBuffer,
     bytes: usize,
-    ok: impl Fn(&[u8]) -> bool,
+    ok: impl FnMut(&[u8]) -> bool,
 ) -> Option<Vec<u8>> {
     find_frame_bits(bits, bytes * 8, ok)
 }
@@ -65,7 +67,7 @@ pub(crate) fn find_frame(
 pub(crate) fn find_frame_bits(
     bits: &BitBuffer,
     want: usize,
-    ok: impl Fn(&[u8]) -> bool,
+    mut ok: impl FnMut(&[u8]) -> bool,
 ) -> Option<Vec<u8>> {
     if bits.len() < want {
         return None;

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -87,9 +87,9 @@ existing pulse front end. Lowest marginal cost, highest coverage gain.
 |---|---|---|---|---|---|---|
 | Fine Offset WH1080 family | 433.92 MHz | OOK PWM 544/1524 us | 31 kHz | done | table | CRC8, matches rtl_433 25.02 field for field |
 | PT2262 / EV1527 / HS1527 fixed code | 315/433.92 MHz | OOK PWM | 31 kHz | synthetic | table | Garage doors, doorbells, cheap sensors. The most common thing on 433. No integrity check at all, so a burst is only claimed when it is exactly one frame long |
-| Nice Flo, CAME, Holtek, Ansonic, Linear | 433.92 MHz | OOK PWM | 31 kHz | table | table | Flipper's fixed-code gate remotes, one table each |
+| Princeton, Holtek, CAME 12/24, Ansonic, Bett, Nice Flo, Linear, Holtek HT12x, Linear Delta3 | 315/433.92 MHz | OOK PWM | 31 kHz | done | table | Flipper's fixed-code gate remotes, ported from Momentum-Firmware. No checksum, so a frame is only claimed when it repeats or the package is plainly one frame, and degenerate all-0/all-1 frames are refused |
 | Chamberlain / Security+ 1.0 and 2.0 | 310/315/390 MHz | OOK PWM | 31 kHz | table | table | Rolling code: readable, not cloneable |
-| KeeLoq, FAAC SLH, Somfy RTS, Star Line | 433.42/433.92 MHz | OOK PWM/Manchester | 31 kHz | table | table | Frames read fine; the payload is encrypted, so a replay is all a transmitter can do with one |
+| KeeLoq, FAAC SLH, Somfy RTS, Star Line | 433.42/433.92 MHz | OOK PWM/Manchester | 31 kHz | table | table | Frames read fine; the payload is encrypted, so a replay is all a transmitter can do with one. Manchester: the slicer's Manchester is untested and there are no captures, so these wait on both before being ported rather than shipping an unverifiable decoder |
 | Acurite 609TXC, 592TXR tower | 433.92 MHz | OOK PPM/PWM | 31 kHz | synthetic | table | Checksum, and per-byte parity on the tower family |
 | LaCrosse TX141TH-Bv2 | 433.92 MHz | OOK PWM | 31 kHz | synthetic | table | LFSR digest, not a CRC |
 | LaCrosse TX29-IT, TX35DTH-IT | 868.24 MHz | FSK NRZ 55/105 us | 125 kHz | synthetic | table | Sync word 0x2dd4, CRC8, BCD temperature |


### PR DESCRIPTION
Ports the fixed-code keyfob remotes from the Flipper Zero firmware
(Momentum-Firmware fork, `lib/subghz/protocols`) into the `decode` crate.

## New decoders

All PWM, one timing table and frame parser each, registered in `Protocols::all()`:

| Protocol | bits | timing (us) | fields |
|---|---|---|---|
| Princeton | 24 | 390/1170 | serial, btn, code |
| Holtek | 40 | 430/870 | serial (LSB-first), btn |
| Holtek HT12x | 12 | 320/640 | serial, btn |
| Ansonic | 12 | 555/1111 | cnt, btn |
| Bett | 18 | 340/2000 | code |
| CAME 12-bit | 12 | 320/640 | code |
| CAME 24-bit | 24 | 320/640 | code |
| Nice Flo | 12 | 700/1400 | code |
| Linear | 10 | 500/1500 | code |
| Linear Delta3 | 8 | 500/2000 | cnt (rolling) |

Files under `crates/decode/src/protocols/keyfob/`, shared helpers in `shared.rs`.

## Two things worth knowing

- **Polarity is not uniform.** Princeton/Holtek/CAME read short-mark-0, which is
  inverted from super-radio's slicer; Ansonic/Linear Delta3 read short-mark-1.
  Each decoder says which.
- **No-checksum protocols false-positive.** These remotes have no integrity
  check, so a decoder must not claim another protocol's burst or noise. The
  decoders reject all-0/all-1 (degenerate) frames and require a frame to be
  corroborated by a repeat unless the package is genuinely one frame. Without
  this, a PPM weather sensor sliced at a keyfob's PWM rate decodes as a
  plausible remote, which is the phantom-device failure the timings suite
  guards against.

## Testing

- 17 new unit tests (one decode + a negative per protocol)
- `decode` suite: 105 lib + 15 `timings` + 4 capture tests pass
- `timings.rs` now also proves the new remotes do not claim the existing
  sensor bursts or noise

## Not in this PR

The rolling-code protocols from the same firmware (KeeLoq, Security+ v1/v2,
Somfy, Marantec, Nice Flor-S) are Manchester-encoded. super-radio's Manchester
slicer is untested and there are no RF captures to validate against, so I left
them out rather than ship an unverifiable decoder; `docs/protocols.md` notes
them as blocked on a tested Manchester slicer + captures.